### PR TITLE
Test Access Control headers

### DIFF
--- a/test/integration/cors_headers_test.rb
+++ b/test/integration/cors_headers_test.rb
@@ -2,14 +2,16 @@ require 'test_helper'
 
 class CorsHeadersTest < ActionDispatch::IntegrationTest
   test "responses include CORS headers" do
-    get '/', headers: {origin: host}
+    [host, 'http://localhost:3000', 'null'].each do |host|
+      get '/', headers: {origin: host}
 
-    assert_includes response.headers, 'Access-Control-Allow-Origin'
-    assert_equal response.headers['Access-Control-Allow-Origin'], host
+      assert_includes response.headers, 'Access-Control-Allow-Origin'
+      assert_equal response.headers['Access-Control-Allow-Origin'], host
 
-    assert_includes response.headers, 'Access-Control-Allow-Methods'
-    %w(GET POST PUT OPTIONS).each do |method|
-      assert_includes response.headers['Access-Control-Allow-Methods'], method
+      assert_includes response.headers, 'Access-Control-Allow-Methods'
+      %w(GET POST PUT OPTIONS).each do |method|
+        assert_includes response.headers['Access-Control-Allow-Methods'], method
+      end
     end
   end
 end

--- a/test/integration/cors_headers_test.rb
+++ b/test/integration/cors_headers_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class CorsHeadersTest < ActionDispatch::IntegrationTest
+  test "responses include CORS headers" do
+    get '/', headers: {origin: host}
+
+    assert_includes response.headers, 'Access-Control-Allow-Origin'
+    assert_equal response.headers['Access-Control-Allow-Origin'], host
+
+    assert_includes response.headers, 'Access-Control-Allow-Methods'
+    %w(GET POST PUT OPTIONS).each do |method|
+      assert_includes response.headers['Access-Control-Allow-Methods'], method
+    end
+  end
+end


### PR DESCRIPTION
We should do this for our other API projects.

In fact, TDD practice would be to have written these tests before committing [these changes](https://github.com/AdaGold/trip_api/commit/d29b75ddde5279af4e1c10e5f1ee52b4c2478974#diff-b1fe55db50c712fef0673345e5b9c0d9R29), or similar code in any of our projects.